### PR TITLE
triton-cns#25 Better support for SRV records

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 (nothing yet)
 
+## 1.4.0
+
+- triton-cns#25: Better support for SRV records
+
 ## 1.3.0
 
 - TRITON-1242: Add `triton.placement.exclude_virtual_servers` boolean tag. This

--- a/lib/cns-svc-tag.pegjs
+++ b/lib/cns-svc-tag.pegjs
@@ -16,10 +16,11 @@ service = name:dnslabel port:(":" int)? props:(":" key "=" value)*
 
     return (svc);
 }
-dnslabel "DNS name" = [a-zA-Z0-9] [a-zA-Z0-9-.]*
+dnslabel "DNS name" = ( [a-zA-Z0-9-] [a-zA-Z0-9-.]* / servicelabel )
 {
     return (text().toLowerCase());
 }
+servicelabel "SRV name" = "_" [a-zA-Z0-9-]* ( "._tcp" / "._udp" )
 key "property name" = [a-z] [a-z0-9-]*
 {
     return (text());

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "triton-tags",
   "description": "Triton tags parsing and validation",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Joyent (joyent.com)",
   "dependencies": {
     "assert-plus": "^1.0.0"

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2018, Joyent, Inc.
+ * Copyright 2021, Joyent, Inc.
  */
 
 /*
@@ -220,6 +220,34 @@ var cases = [
         key: 'triton.cns.services',
         str: '5foobar',
         val: '5foobar'
+    },
+    // _service._protocol support
+    {
+        key: 'triton.cns.services',
+        str: '_ldap._tcp:389',
+        val: '_ldap._tcp:389'
+    },
+    {
+        key: 'triton.cns.services',
+        str: '_dns._udp:389',
+        val: '_dns._udp:389'
+    },
+    {
+        key: 'triton.cns.services',
+        str: '_foo._tcp:123:priority=20:weight=20',
+        val: '_foo._tcp:123:priority=20:weight=20'
+    },
+    {
+        key: 'triton.cns.services',
+        str: '_foo._bar:389',
+        /* JSSTYLED */
+        err: /Expected DNS name but "_" found/
+    },
+    {
+        key: 'triton.cns.services',
+        str: '_tcp:389',
+        /* JSSTYLED */
+        err: /Expected DNS name but "_" found/
     }
 
     // TODO: triton.cns.reverse_ptr


### PR DESCRIPTION
New tests added for the updated tag syntax. Before updating `cns-service-tag.pegjs` these tests failed. After updating all the tests pass with expected output.